### PR TITLE
Removed safe navigation operator

### DIFF
--- a/auth/app/controllers/concerns/push_type/api_authentication_methods.rb
+++ b/auth/app/controllers/concerns/push_type/api_authentication_methods.rb
@@ -23,7 +23,7 @@ module PushType
     end
 
     def auth_token
-      params[:token] || request.headers['Authorization']&.split&.last
+      params[:token] || request.headers['Authorization'].try(:split).try(:last)
     end
 
   end


### PR DESCRIPTION
Used [this](http://mitrev.net/ruby/2015/11/13/the-operator-in-ruby/) to figure out how to remove the operator. Hope it's correct.